### PR TITLE
Added rate limiting

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,6 +14,8 @@ const PORT = process.env.PORT || 5000
 app.use(express.json())
 app.use('', router)
 
+app.use('*', (_req, res) => res.send(404).send('You seem to be lost!'))
+
 app.listen(PORT, () =>
   console.log(
     `Server running in ${process.env.NODE_ENV} mode on PORT ${PORT}...`

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "dotenv": "^16.0.2",
     "express": "^4.18.1",
+    "express-rate-limit": "^6.7.0",
     "mongoose": "^6.5.4",
     "nanoid": "^4.0.0",
     "valid-url": "^1.0.9"

--- a/routes/url.route.js
+++ b/routes/url.route.js
@@ -1,14 +1,18 @@
 import express from 'express'
+import rateLimit from 'express-rate-limit'
 import { saveUrl, getUrl } from '../controllers/url.controller.js'
 
 const router = express.Router()
 
-router.post('/', saveUrl)
-
-router.get('/:id', getUrl)
-
-router.get('*', (_req, res) => {
-  res.status(404).send('You seem to be lost!')
+// Rate limit requests to 1 per second
+const limiter = rateLimit({
+  windowMs: 1000,
+  max: 1,
+  standardHeaders: true,
+  legacyHeaders: false,
 })
+
+router.post('/', limiter, saveUrl)
+router.get('/:id', limiter, getUrl)
 
 export default router

--- a/yarn.lock
+++ b/yarn.lock
@@ -909,6 +909,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"express-rate-limit@npm:^6.7.0":
+  version: 6.7.0
+  resolution: "express-rate-limit@npm:6.7.0"
+  peerDependencies:
+    express: ^4 || ^5
+  checksum: 7bd3f298b202cdb11c3d7c2dcff9be12c6885be5e64fb112f6c79103ba93a8e5d899ce15a5a3ce48f82190ab3515bed403e067dc3e42fc2832558cbe2620f955
+  languageName: node
+  linkType: hard
+
 "express@npm:^4.18.1":
   version: 4.18.1
   resolution: "express@npm:4.18.1"
@@ -2561,6 +2570,7 @@ __metadata:
     cross-env: ^7.0.3
     dotenv: ^16.0.2
     express: ^4.18.1
+    express-rate-limit: ^6.7.0
     mongoose: ^6.5.4
     nanoid: ^4.0.0
     nodemon: ^2.0.19


### PR DESCRIPTION
- Added rate limiting middleware to routes performing database access (currently set to 1 request per second).
- Better handling for 404s.

Closes #2 